### PR TITLE
Add sortable relation example usage

### DIFF
--- a/controllers/Cities.php
+++ b/controllers/Cities.php
@@ -12,11 +12,14 @@ class Cities extends Controller
 
     public $implement = [
         'Backend.Behaviors.FormController',
-        'Backend.Behaviors.ListController'
+        'Backend.Behaviors.ListController',
+        'Backend.Behaviors.RelationController',
+        'Backend.Behaviors.ReorderRelationController',
     ];
 
     public $formConfig = 'config_form.yaml';
     public $listConfig = 'config_list.yaml';
+    public $relationConfig = 'config_relation.yaml';
 
     public function __construct()
     {
@@ -24,6 +27,13 @@ class Cities extends Controller
 
         BackendMenu::setContext('Winter.Test', 'test', 'cities');
     }
+
+    public function relationExtendManageWidget($widget, $field, $model)
+    {
+        if ($field === 'locations' && $widget->context === 'create') {
+            $widget->data->country_id = $model->country->id;
+        }
+   }
 
     public function onGetInspectorConfiguration()
     {

--- a/controllers/cities/_locations.htm
+++ b/controllers/cities/_locations.htm
@@ -1,0 +1,1 @@
+<?= $this->relationRender('locations') ?>

--- a/controllers/cities/config_relation.yaml
+++ b/controllers/cities/config_relation.yaml
@@ -1,0 +1,11 @@
+locations:
+    label: Locations
+    list: $/winter/test/models/location/columns.yaml
+    form: $/winter/test/models/location/fields.yaml
+    view:
+        toolbarButtons: create|delete
+        sortable: true
+        defaultSort:
+            column: sort_order
+            direction: asc
+

--- a/models/City.php
+++ b/models/City.php
@@ -8,11 +8,16 @@ use Model;
 class City extends Model
 {
     use \System\Traits\PropertyContainer;
+    use \Winter\Storm\Database\Traits\HasSortableRelations;
 
     /**
      * @var string The database table used by the model.
      */
     public $table = 'winter_test_cities';
+
+    public $sortableRelations = [
+        'locations' => 'sort_order',
+    ];
 
     /*
      * Disable timestamps by default.

--- a/models/city/fields.yaml
+++ b/models/city/fields.yaml
@@ -16,6 +16,9 @@ fields:
         type: relation
         span: right
 
+    locations:
+        type: partial
+
     _inspector:
         label: City information
         type: partial

--- a/models/location/columns.yaml
+++ b/models/location/columns.yaml
@@ -13,3 +13,4 @@ columns:
         label: Country
         relation: country
         select: name
+    sort_order:

--- a/models/location/fields.yaml
+++ b/models/location/fields.yaml
@@ -5,4 +5,9 @@
 fields:
     id:
         label: ID
-        disabled: true
+        hidden: true
+    name:
+        label: Location name
+
+    country:
+        hidden: true

--- a/updates/v2.0.1/modify_locations_table.php
+++ b/updates/v2.0.1/modify_locations_table.php
@@ -1,0 +1,23 @@
+<?php namespace Winter\Test\Updates;
+
+use Schema;
+use Winter\Storm\Database\Updates\Migration;
+
+class ModifyLocationsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('winter_test_locations', function ($table) {
+            $table->unsignedinteger('sort_order')->nullable()->index()->default(1);
+        });
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('winter_test_locations', 'sort_order')) {
+            Schema::table('winter_test_locations', function ($table) {
+                $table->dropColumn('sort_order');
+            });
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -7,3 +7,6 @@
     - v1.0.3/seed_tables.php
 "2.0.0": 
     - "Rebrand to Winter.Test"
+"2.0.1":
+    - "Add Relation Reorder example"
+    - v2.0.1/modify_locations_table.php


### PR DESCRIPTION
Requires the following PRs:

- https://github.com/wintercms/storm/pull/78
- https://github.com/wintercms/winter/pull/512

Adds sortable relations to the Cities `locations` relation.