### PR TITLE
Trigger applyFiltersFromModel bug in getSaveData

### DIFF
--- a/models/Gallery.php
+++ b/models/Gallery.php
@@ -28,6 +28,7 @@ class Gallery extends Model
 
     public $rules = [
         'title' => 'required|between:3,255',
+        'party_mode' => 'required_if:status,active',
     ];
 
     /**
@@ -44,4 +45,15 @@ class Gallery extends Model
     public $attachMany = [
         'images' => 'System\Models\File',
     ];
+
+    public function filterFields($fields, $context)
+    {
+        if (isset($fields->status) && isset($fields->party_mode)) {
+            if ($fields->status->value === 'active') {
+                $fields->party_mode->hidden = false;
+            } else {
+                $fields->party_mode->hidden = true;
+            }
+        }
+    }
 }

--- a/models/gallery/fields.yaml
+++ b/models/gallery/fields.yaml
@@ -22,10 +22,8 @@ fields:
         type: checkbox
         attributes:
             required: 1
-        trigger:
-            field: status
-            condition: value[active]
-            action: show|enable
+        required: true
+        dependsOn: status
 
 tabs:
     fields:


### PR DESCRIPTION
Note: this is a very simple demonstration. One could use the field's `trigger` config to achieve the same, but more complex cases that cannot rely on `trigger` would need to use filterFields with field dependencies.